### PR TITLE
Fix spelling errors and ValueError

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ This is a GRU-based neural network designed for English word syllabification. Th
 
 ## Usage
 
-Use the `syllabify()` function from the `Syllabel` class to syllabify your words:
+Use the `syllabify()` function from the `Syllable` class to syllabify your words:
 
->     >>> from eng_syl.syllabify import Syllabel
->     >>> syllabler = Syllabel()
+>     >>> from eng_syl.syllabify import Syllable
+>     >>> syllabler = Syllable()
 >     >>> syllabler.syllabify("chomsky")
 >     'chom-sky'
 
@@ -36,5 +36,5 @@ The `ipafy()` function from the  `on_to_phon` class tries to approximate an IPA 
 >     >>> print(skibidi.ipafy(['b', 'u', 'tt'])
 >     'bʌt'
 
- - **sequence**: *array of strings* - sa sequence of English viable onsets, nuclei, and coda
+ - **sequence**: *array of strings* - a sequence of English viable onsets, nuclei, and coda
 

--- a/eng_syl/syllabify.py
+++ b/eng_syl/syllabify.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 
 
-class Syllabel:
+class Syllable:
     def __init__(self,e2i_ortho ='e2i.pkl', ortho_input_size=45, latent_dim=256, embed_dim=256, max_feat=259):
         self.this_dir, this_filename = os.path.split(__file__)
         path_clean = os.path.join(self.this_dir, 'clean.pkl')

--- a/eng_syl/syllabify.py
+++ b/eng_syl/syllabify.py
@@ -1,4 +1,4 @@
-from tensorflow.keras.layers import  Dense, TimeDistributed, Bidirectional, Input, Embedding, Activation, GRU, ZeroPadding1D
+from tensorflow.keras.layers import Dense, TimeDistributed, Bidirectional, Input, Embedding, Activation, GRU, ZeroPadding1D
 from tensorflow.keras.models import Model
 from tensorflow.keras import regularizers
 from tensorflow.keras.preprocessing.sequence import pad_sequences
@@ -6,75 +6,63 @@ import pickle
 import numpy as np
 import os
 
-
 class Syllable:
-    def __init__(self,e2i_ortho ='e2i.pkl', ortho_input_size=45, latent_dim=256, embed_dim=256, max_feat=259):
-        self.this_dir, this_filename = os.path.split(__file__)
+    def __init__(self, e2i_ortho='e2i.pkl', ortho_input_size=45, latent_dim=256, embed_dim=256, max_feat=259):
+        self.this_dir = os.path.dirname(os.path.abspath(__file__))
         path_clean = os.path.join(self.this_dir, 'clean.pkl')
-        self.clean = pickle.load(open(path_clean,'rb'))
+        with open(path_clean, 'rb') as f:
+            self.clean = pickle.load(f)
         path_e2i = os.path.join(self.this_dir, e2i_ortho)
-        self.e2i_ortho = pickle.load(open(path_e2i, 'rb'))
+        with open(path_e2i, 'rb') as f:
+            self.e2i_ortho = pickle.load(f)
         self.ortho_input_size = ortho_input_size
         self.latent_dim = latent_dim
         self.embed_dim = embed_dim
         self.max_feat = max_feat
         self.model = self.build_model()
-        self.model.load_weights(os.path.join(self.this_dir,'syllabler_best_weights.h5'))
-
+        self.model.load_weights(os.path.join(self.this_dir, 'syllabler_best_weights.h5'))
 
     def build_model(self):
-        
-        # orthographic and ipa input layers
-        ortho_inputs = Input(self.ortho_input_size,)
-        # first branch ortho
-        x = Embedding(self.max_feat, self.embed_dim, input_length=self.ortho_input_size)(ortho_inputs)
-        x = Bidirectional(GRU(self.latent_dim, return_sequences=True, recurrent_dropout = 0.2, activity_regularizer=regularizers.l2(1e-5)), input_shape=(self.ortho_input_size, 1))(x)
-        x = Bidirectional(GRU(self.latent_dim, return_sequences=True, recurrent_dropout = 0.2, activity_regularizer= regularizers.l2(1e-5) ), input_shape=(self.ortho_input_size, 1))(x)
-        # x = TimeDistributed(Dense(3, activation = 'softmax'))(x)
-        x = ZeroPadding1D(padding=(0, self.ortho_input_size - x.shape[1]))(x)
-        z = TimeDistributed(Dense(3))(x)
-        z = Activation('softmax')(z)
-        
+        # orthographic input layer
+        ortho_inputs = Input(shape=(self.ortho_input_size,))
+        # embedding layer
+        x = Embedding(input_dim=self.max_feat, output_dim=self.embed_dim)(ortho_inputs)
+        # bidirectional GRU layers
+        x = Bidirectional(GRU(units=self.latent_dim, return_sequences=True, recurrent_dropout=0.2, activity_regularizer=regularizers.l2(1e-5)))(x)
+        x = Bidirectional(GRU(units=self.latent_dim, return_sequences=True, recurrent_dropout=0.2, activity_regularizer=regularizers.l2(1e-5)))(x)
+        # time distributed dense layer
+        x = TimeDistributed(Dense(units=3))(x)
+        # activation layer
+        z = Activation('softmax')(x)
+        # define the model
         model = Model(inputs=[ortho_inputs], outputs=z)
-        
         return model
-    
+
     def syllabify(self, word):
         if word in self.clean:
             return self.clean[word]
-        inted_ortho = []
-        for c in word.lower():
-            inted_ortho += [self.e2i_ortho[c]]
-            
-        
+        inted_ortho = [self.e2i_ortho[c] for c in word.lower()]
         inted_ortho = pad_sequences([inted_ortho], maxlen=self.ortho_input_size, padding='post')[0]
-        predicted = self.model.predict(inted_ortho.reshape(1, self.ortho_input_size, 1), verbose = 0)[0]
+        predicted = self.model.predict(inted_ortho.reshape(1, self.ortho_input_size), verbose=0)[0]
         indexes = self.to_ind(predicted)
         converted = self.insert_syl(word, indexes)
         return converted
 
     def machine_syllabify(self, word):
-        inted_ortho = []
-        for c in word.lower():
-            inted_ortho += [self.e2i_ortho[c]]
-
-
+        inted_ortho = [self.e2i_ortho[c] for c in word.lower()]
         inted_ortho = pad_sequences([inted_ortho], maxlen=self.ortho_input_size, padding='post')[0]
-        predicted = self.model.predict(inted_ortho.reshape(1, self.ortho_input_size, 1), verbose = 0)[0]
+        predicted = self.model.predict(inted_ortho.reshape(1, self.ortho_input_size), verbose=0)[0]
         indexes = self.to_ind(predicted)
         converted = self.insert_syl(word, indexes)
         return converted
 
     def to_ind(self, sequence):
-        index_sequence = []
-        for ind in sequence:
-            index_sequence += [np.argmax(ind)]
+        index_sequence = [np.argmax(ind) for ind in sequence]
         return index_sequence
-    
+
     def insert_syl(self, word, indexes):
         index_list = np.where(np.array(indexes) == 2)[0]
-        word_array = [*word]
-        for i in range(0, len(index_list)):
+        word_array = list(word)
+        for i in range(len(index_list)):
             word_array.insert(index_list[i] + i + 1, '-')
         return ''.join(word_array)
-


### PR DESCRIPTION
While going through the project description, I found a few typos, notably in the `Syllabel` class. I thought it would be best to fix these errors in the code.

I also ran into a number of errors when running the code on my machine, such as:
```
Traceback (most recent call last):
  File "/home/anova02/Developer Projects/eng-syl/tests.main.py", line 3, in <module>
    syllabler = eng_syl.syllabify.Syllable()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anova02/Developer Projects/eng-syl/eng_syl/syllabify.py", line 21, in __init__
    self.model = self.build_model()
                 ^^^^^^^^^^^^^^^^^^
  File "/home/anova02/Developer Projects/eng-syl/eng_syl/syllabify.py", line 28, in build_model
    ortho_inputs = Input(self.ortho_input_size,)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anova02/.local/lib/python3.11/site-packages/keras/src/layers/core/input_layer.py", line 143, in Input
    layer = InputLayer(
            ^^^^^^^^^^^
  File "/home/anova02/.local/lib/python3.11/site-packages/keras/src/layers/core/input_layer.py", line 46, in __init__
    shape = backend.standardize_shape(shape)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anova02/.local/lib/python3.11/site-packages/keras/src/backend/common/variables.py", line 442, in standardize_shape
    raise ValueError(f"Cannot convert '{shape}' to a shape.")
ValueError: Cannot convert '45' to a shape.
```
I fixed the error by removing the `input_length` argument in your `Embedding` in [this commit](https://github.com/ellipse-liu/eng-syl/commit/5e2c1959e61e932c278da8e11ada006e2ddbbf94).